### PR TITLE
Add docker dev file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM python:3.9.1
+
+WORKDIR /app
+
+# Copy in reqired files
+COPY requirements.txt ./
+
+# Install Python Requirements
+RUN pip install -U pip
+RUN pip install -r requirements.txt
+
+# Install VIM and Bash completion
+RUN apt-get update
+RUN apt-get install -y vim
+RUN apt-get install -y bash-completion
+
+# Jupyter, from https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+ENV TINI_VERSION v0.6.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN apt-get update
 RUN apt-get install -y vim
 RUN apt-get install -y bash-completion
 
-# Jupyter, from https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+# Jupyter, from https://jupyter-notebook.readthedocs.io/en/stable/public_server.html#docker-cmd
 ENV TINI_VERSION v0.6.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
 RUN chmod +x /usr/bin/tini

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,3 +19,5 @@ ENV TINI_VERSION v0.6.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
 RUN chmod +x /usr/bin/tini
 ENTRYPOINT ["/usr/bin/tini", "--"]
+
+EXPOSE 8888

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+IMAGE := tagr-dev-image:1.0
+.PHONY: build
+build:
+	@echo "Building image..."
+	@docker build -t ${IMAGE} -f Dockerfile.dev .
+	@echo "Building image and opening shell..."
+	@docker run -it -p 8888:8888 -v ${PWD}:/app -w /app ${IMAGE} /bin/bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 boto3
 s3fs
 pylint
+jupyter


### PR DESCRIPTION
Adding a docker dev file and other productivity goodies to standardize local development. No more pyenv!

**Changes:**
The docker file mounts the local directory as a volume meaning any code changes will be applied immediately to the container. No need to tear down the container every change.

Spin up the container with `make`. This will abstract away all the gross docker commands. 

Getting `.aws/credentials` into the container will be a pain. Provide AWS crews via `.env` file instead. Simply `source .env.sample` inside the container. Long term we can provide a more elegant solution for users to supply creds.

I personally like to debug with a notebook. I've added Jupyter into the container definition. To avoid kernal crashes in docker, we're using Tini as our container entry point. Read more here https://jupyter-notebook.readthedocs.io/en/stable/public_server.html#docker-cmd
To spin up jupyter from container: `jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root`

Local storage does not work quite right inside the container since we make fs assumptions when writing. Will fix in a future PR