### PR TITLE
Generate folder directories when flushing to local storage

### DIFF
--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -1,9 +1,12 @@
 import json
 import pickle
+import os
+import logging
 
+logger = logging.getLogger("tagging_artifact")
 
 class Local:
-    def dump_csv(self, df, proj, exp, tag, filename):
+    def dump_csv(self, df, proj, experiment, tag, filename):
         """
         turns dataframe into csv and saves it to local storage
 
@@ -15,9 +18,9 @@ class Local:
         tag: custom commit message
         filename: filename to be saved locally
         """
-        df.to_csv("{}-{}-{}-{}.csv".format(proj, exp, tag, filename), index=False)
+        df.to_csv("{}/{}/{}/{}.csv".format(proj, experiment, tag, filename), index=False)
 
-    def dump_json(self, df_metadata, proj, exp, tag):
+    def dump_json(self, df_metadata, proj, experiment, tag):
         """
         turns dataframe into csv and saves it to local storage
 
@@ -28,10 +31,10 @@ class Local:
         exp: experiment name
         tag: custom commit message
         """
-        with open("{}-{}-df_summary.json".format(exp, tag), 'w') as outfile:
+        with open("{}/{}/{}/df_summary.json".format(proj, experiment, tag), 'w') as outfile:
             json.dump(df_metadata, outfile, default=str)
 
-    def dump_pickle(self, pickle_object, proj, exp, tag, filename):
+    def dump_pickle(self, pickle_object, proj, experiment, tag, filename):
         """
         turns dataframe into csv and saves it to local storage
 
@@ -44,5 +47,12 @@ class Local:
         filename: filename to be exported
         """
         pickle.dump(pickle_object, open(
-            "{}-{}-{}-{}.pkl".format(proj, exp, tag, filename), "wb"
+            "{}/{}/{}/{}.pkl".format(proj, experiment, tag, filename), "wb"
         ))
+    
+    def build_path(self, proj, experiment, tag):
+        try:
+            os.makedirs("{}/{}/{}".format(proj, experiment, tag))
+        except OSError:
+            print("The directory %s already exists" % "{}/{}/{}".format(proj, experiment, tag))
+    

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -3,7 +3,7 @@ import pickle
 import os
 import logging
 
-logger = logging.getLogger("tagging_artifact")
+logger = logging.getLogger("saving experiment to local storage")
 
 class Local:
     def dump_csv(self, df, proj, experiment, tag, filename):
@@ -54,4 +54,5 @@ class Local:
         try:
             os.makedirs("{}/{}/{}".format(proj, experiment, tag))
         except OSError:
-            print("The directory %s already exists" % "{}/{}/{}".format(proj, experiment, tag))
+            #"The directory waterflow-tagr/sunrise/testlocal already exists. If using the tag argument, please provide a new unique identifier"
+            logger.info("The directory %s already exists. If using the tag argument, please provide a new unique identifier." % "{}/{}/{}".format(proj, experiment, tag))

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -55,4 +55,3 @@ class Local:
             os.makedirs("{}/{}/{}".format(proj, experiment, tag))
         except OSError:
             print("The directory %s already exists" % "{}/{}/{}".format(proj, experiment, tag))
-    

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -79,7 +79,7 @@ class Tags(object):
             {"artifact": artifact, "type": types}, index=EXP_OBJECTS + cust_keys
         )
 
-    def flush(self, proj, exp, dump='local', tag=None):
+    def flush(self, proj, experiment, dump='local', tag=None):
         """
         Pushes all variables from `queue` to metadata store.
         Generates metadata for artifacts of type pd.Dataframe in JSON
@@ -105,6 +105,9 @@ class Tags(object):
         if not tag:
             logger.info("using datetime as tag")
             tag = str(datetime.utcnow())
+        
+        # if folder directory doesnt exist, then create new directory
+        self.storage_provider.build_path(proj, experiment, tag)
 
         #####################
         # generate metadata #
@@ -131,9 +134,9 @@ class Tags(object):
             # Push dfs #
             #############
             # todo: save larger dfs as parquet, maybe partition as well
-            logger.info("saving dataframes as csv to " + str(dump))
+            logger.info("saving/flushing dataframes as csv to " + str(dump))
             # push csv
-            self.storage_provider.dump_csv(df, proj, exp, tag, df_name)
+            self.storage_provider.dump_csv(df, proj, experiment, tag, df_name)
 
         nums_and_strings = list(
             summary[summary["type"].isin(["int", "float", "str"])].index
@@ -152,15 +155,15 @@ class Tags(object):
             "nums_and_strings": nums_and_strings_dict,
         }
 
-        logger.info("pushing metadata json to S3")
+        logger.info("flushing metadata json to " + str(dump))
 
-        self.storage_provider.dump_json(df_metadata, proj, exp, tag)
+        self.storage_provider.dump_json(df_metadata, proj, experiment, tag)
 
-        logger.info("saving models to s3")
+        logger.info("saving/flushing models to " + str(dump))
         models = list(summary[summary["type"] == "model"].index)
 
         for model in models:
             model_object = summary["artifact"].loc[model]
             pickle_byte_obj = pickle.dumps(model_object)
-            logger.info("pushing " + str(model) + "metadata json to S3")
-            self.storage_provider.dump_pickle(pickle_byte_obj, proj, exp, tag, model)
+            logger.info("flushing " + str(model) + "metadata json to S3")
+            self.storage_provider.dump_pickle(pickle_byte_obj, proj, experiment, tag, model)

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -133,7 +133,7 @@ class Tags(object):
             # Push dfs #
             #############
             # todo: save larger dfs as parquet, maybe partition as well
-            logger.info("saving/flushing dataframes as csv to " + str(dump))
+            logger.info("flushing dataframes as csv to " + str(dump))
             # push csv
             self.storage_provider.dump_csv(df, proj, experiment, tag, df_name)
 
@@ -158,7 +158,7 @@ class Tags(object):
 
         self.storage_provider.dump_json(df_metadata, proj, experiment, tag)
 
-        logger.info("saving/flushing models to " + str(dump))
+        logger.info("flushing models to " + str(dump))
         models = list(summary[summary["type"] == "model"].index)
 
         for model in models:

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -94,20 +94,19 @@ class Tags(object):
             - for dump, asssume local by default if destination not provided
         """
         # todo create metadata provider file to hook into s3 and blob
+        
+        # use datetime as index if tag name not provided
+        if not tag:
+            logger.info("using datetime as tag")
+            tag = str(datetime.utcnow())
 
         # determine which storage provider to use
         if dump == 'aws':
             self.storage_provider = Aws()
         elif dump == 'local':
             self.storage_provider = Local()
-
-        # use datetime as index if tag name not provided
-        if not tag:
-            logger.info("using datetime as tag")
-            tag = str(datetime.utcnow())
-        
-        # if folder directory doesnt exist, then create new directory
-        self.storage_provider.build_path(proj, experiment, tag)
+            # if folder directory doesnt exist, then create new directory
+            self.storage_provider.build_path(proj, experiment, tag)
 
         #####################
         # generate metadata #


### PR DESCRIPTION
# Description
This PR addresses https://github.com/tagr-dev/tagr/issues/11

In the past, when the user pushes to local storage, tagr would simply push the metadata files in the current dir path instead of creating folder directories to place these files in. Like over here for dump_csv:
```
def dump_csv(self, df, proj, exp, tag, filename):
        df.to_csv("{}-{}-{}-{}.csv".format(proj, exp, tag, filename), index=False)
```
We don't want to append the proj and path variables to the filename we're generating, instead we want to store experiment metadata in separate folders to keep things more organized for the user.

# Changes
- Changed all occurences of ```exp``` to ```experiment``` just to keep things more readable
- In ```local.py```, I've added an additional function called ```build_path(self, proj, experiment, tag)```, which gets invoked at the start of ```flush()``` in ```artifacts.py```. That way, before tagr pushes the metadata, it would build the folder directory and then push the metadata to that directory.
- (I just realized that we don't need to do this for ```s3``` since it already builds the paths on its own if they dont exist beforehand)
- Refactored the dumping functions for ```local.py```
- Edited logging statements being invoked in ```flush()```