### PR TITLE
Fixed some docstrings

### DIFF
--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -40,7 +40,7 @@ class Aws:
         ----------
         df_metadata: json object containing experiment metadata
         proj: project name on metadata provider
-        exp: experiment name
+        experiment: experiment name
         tag: custom commit message
         """
         self.S3.Object(proj, "{}/{}/df_summary.json".format(exp, tag)).put(
@@ -56,7 +56,7 @@ class Aws:
         ----------
         pickle_object: model that has been serialized into a pickle object
         proj: project name on metadata provider
-        exp: experiment name
+        experiment: experiment name
         tag: custom commit message
         filename: filename to be exported
         """

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -15,7 +15,7 @@ class Aws:
     def __init__(self):
         self.S3 = boto3.resource("s3")
 
-    def dump_csv(self, df, proj, exp, tag, filename):
+    def dump_csv(self, df, proj, experiment, tag, filename):
         """
         turns dataframe into csv and saves it to s3 directory
 
@@ -28,11 +28,11 @@ class Aws:
         filename: filename to be exported
         """
         df.to_csv(csv_buffer)
-        self.S3.Object(proj, "{}/{}/{}.csv".format(exp, tag, filename)).put(
+        self.S3.Object(proj, "{}/{}/{}.csv".format(experiment, tag, filename)).put(
             Body=csv_buffer.getvalue()
         )
 
-    def dump_json(self, df_metadata, proj, exp, tag):
+    def dump_json(self, df_metadata, proj, experiment, tag):
         """
         turns dataframe into csv and saves it to s3 directory
 
@@ -43,12 +43,12 @@ class Aws:
         experiment: experiment name
         tag: custom commit message
         """
-        self.S3.Object(proj, "{}/{}/df_summary.json".format(exp, tag)).put(
+        self.S3.Object(proj, "{}/{}/df_summary.json".format(exper, tag)).put(
             Body=(bytes(json.dumps(df_metadata, cls=NpEncoder).encode("UTF-8"))),
             ContentType="application/json",
         )
 
-    def dump_pickle(self, pickle_object, proj, exp, tag, filename):
+    def dump_pickle(self, pickle_object, proj, experiment, tag, filename):
         """
         turns dataframe into csv and saves it to s3 directory
 
@@ -60,6 +60,6 @@ class Aws:
         tag: custom commit message
         filename: filename to be exported
         """
-        self.S3.Object(proj, "{}/{}/{}.pkl".format(exp, tag, filename)).put(
+        self.S3.Object(proj, "{}/{}/{}.pkl".format(experiment, tag, filename)).put(
             Body=pickle_object
         )

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -14,7 +14,7 @@ class Local:
         ----------
         df: dataframe object
         proj: project name 
-        exp: experiment name
+        experiment: experiment name
         tag: custom commit message
         filename: filename to be saved locally
         """
@@ -28,7 +28,7 @@ class Local:
         ----------
         df_metadata: json object containing experiment metadata
         proj: project name 
-        exp: experiment name
+        experiment: experiment name
         tag: custom commit message
         """
         with open("{}/{}/{}/df_summary.json".format(proj, experiment, tag), 'w') as outfile:
@@ -42,7 +42,7 @@ class Local:
         ----------
         pickle_object: model that has been serialized into a pickle object
         proj: project name 
-        exp: experiment name
+        experiment: experiment name
         tag: custom commit message
         filename: filename to be exported
         """
@@ -51,8 +51,16 @@ class Local:
         ))
     
     def build_path(self, proj, experiment, tag):
+        """
+        sets up a folder directory within local storage to push metadata to
+
+        Parameters
+        ----------
+        proj: project name 
+        experiment: experiment name
+        tag: custom commit message
+        """
         try:
             os.makedirs("{}/{}/{}".format(proj, experiment, tag))
         except OSError:
-            #"The directory waterflow-tagr/sunrise/testlocal already exists. If using the tag argument, please provide a new unique identifier"
             logger.info("The directory %s already exists. If using the tag argument, please provide a new unique identifier." % "{}/{}/{}".format(proj, experiment, tag))


### PR DESCRIPTION
# Description
Forgot to change occurrences of ```exp``` to ```experiment``` in our storage files for ```local``` and ```aws```.
That way, we can stay consistent with variable naming across tagr.

Also, I added docstring explanation for ```build_path()``` for local.py. Forgot to do this in the previous PR.

