### PR TITLE
tagr.list() functionality

### DIFF
--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -5,11 +5,11 @@ Aws S3 class implementation
 import json
 from io import StringIO
 import boto3
-
+from tagr.storage.aws_helper import AwsHelper
 from tagr.utils import NpEncoder
 
 csv_buffer = StringIO()
-
+aws_helper = AwsHelper()
 
 class Aws:
     def __init__(self):
@@ -65,6 +65,7 @@ class Aws:
         )
 
     def list(self, proj, experiment, tag):
+        
         '''
         gets list of files/folders located at {proj}/{experiment}/{tag}
 
@@ -74,15 +75,11 @@ class Aws:
         experiment: experiment name 
         tag: custom commit message (optional)
         '''
-        folders = []
+        
         object_path = experiment
         if tag:
             object_path += ('/' + tag)
 
-        bucket = self.S3.Bucket(proj)
-        
-        for obj in bucket.objects.all():
-            if obj.key.startswith(object_path):
-                folders.append(proj + '/' + obj.key)
-        #folders = self.S3.list_buckets()
-        return folders
+        return aws_helper.get_list_of_tables(proj, object_path)
+
+    

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -43,7 +43,7 @@ class Aws:
         experiment: experiment name
         tag: custom commit message
         """
-        self.S3.Object(proj, "{}/{}/df_summary.json".format(exper, tag)).put(
+        self.S3.Object(proj, "{}/{}/df_summary.json".format(experiment, tag)).put(
             Body=(bytes(json.dumps(df_metadata, cls=NpEncoder).encode("UTF-8"))),
             ContentType="application/json",
         )

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -63,3 +63,8 @@ class Aws:
         self.S3.Object(proj, "{}/{}/{}.pkl".format(exp, tag, filename)).put(
             Body=pickle_object
         )
+
+    def fetch(self, proj, path):
+        folders = self.S3.list_objects(proj) 
+        print(folders)
+        return folders

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -65,7 +65,6 @@ class Aws:
         )
 
     def list(self, proj, experiment, tag):
-        
         '''
         gets list of files/folders located at {proj}/{experiment}/{tag}
 
@@ -75,11 +74,8 @@ class Aws:
         experiment: experiment name 
         tag: custom commit message (optional)
         '''
-        
         object_path = experiment
         if tag:
             object_path += ('/' + tag)
 
         return aws_helper.get_list_of_tables(proj, object_path)
-
-    

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -3,13 +3,13 @@ Aws S3 class implementation
 """
 
 import json
-from io import StringIO
 import boto3
+
+from io import StringIO
 from tagr.storage.aws_helper import AwsHelper
 from tagr.utils import NpEncoder
 
 csv_buffer = StringIO()
-aws_helper = AwsHelper()
 
 class Aws:
     def __init__(self):
@@ -64,16 +64,16 @@ class Aws:
             Body=pickle_object
         )
 
-    def list(self, proj, experiment, tag):
-        '''
+    def __list(self, proj, experiment, tag):
+        aws_helper = AwsHelper()
+        """
         gets list of files/folders located at {proj}/{experiment}/{tag}
-
         Parameters
         __________
         proj: project name (s3 bucket name)
         experiment: experiment name 
         tag: custom commit message (optional)
-        '''
+        """
         object_path = experiment
         if tag:
             object_path += ('/' + tag)

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -64,7 +64,7 @@ class Aws:
             Body=pickle_object
         )
 
-    def __list(self, proj, experiment, tag):
+    def _Tags__list(self, proj, experiment, tag):
         aws_helper = AwsHelper()
         """
         gets list of files/folders located at {proj}/{experiment}/{tag}

--- a/tagr/storage/aws_helper.py
+++ b/tagr/storage/aws_helper.py
@@ -30,11 +30,9 @@ class AwsHelper:
 
         while True:
 
-            # The S3 API response is a large blob of metadata.
+            # The S3 API response is a large dict of metadata.
             # 'Contents' contains information about the listed objects.
             resp = s3.list_objects_v2(**kwargs)
-            print("s3 response")
-            print(resp)
 
             try:
                 contents = resp['Contents']

--- a/tagr/storage/aws_helper.py
+++ b/tagr/storage/aws_helper.py
@@ -1,0 +1,84 @@
+'''
+code heavy helper functions for Aws.py
+
+'''
+import boto3
+
+class AwsHelper:
+    def get_matching_s3_objects(self, bucket, object_path='', max_keys_per_request=1):
+        """
+        List objects in an S3 bucket.
+
+        Parameters
+        ----------
+        bucket: Name of the S3 bucket.
+        object_path: Path that leads to all tables
+        max_keys_per_request: number of objects to list down
+        """
+
+        s3 = boto3.client('s3')
+        kwargs = {'Bucket': bucket}
+
+        # If the prefix is a single string (not a tuple of strings), we can
+        # do the filtering directly in the S3 API.
+        if isinstance(object_path, str):
+            kwargs['Prefix'] = object_path
+        else:
+            kwargs['Prefix'] = str(object_path)
+
+        kwargs['MaxKeys'] = max_keys_per_request
+
+        while True:
+
+            # The S3 API response is a large blob of metadata.
+            # 'Contents' contains information about the listed objects.
+            resp = s3.list_objects_v2(**kwargs)
+
+            try:
+                contents = resp['Contents']
+            except KeyError:
+                return
+
+            for obj in contents:
+                key = obj['Key']
+                if key.startswith(object_path):
+                    yield obj
+
+            # The S3 API is paginated, returning up to 1000 keys at a time.
+            # Pass the continuation token into the next response, until we
+            # reach the final page (when this field is missing).
+            try:
+                kwargs['ContinuationToken'] = resp['NextContinuationToken']
+            except KeyError:
+                break
+
+    def get_matching_s3_keys(self, bucket, object_path='', max_keys_per_request=1):
+        """
+        Generate the keys in an S3 bucket.
+
+        Parameters
+        ----------
+        bucket: Name of the S3 bucket.
+        object_path: Path that leads to all tables 
+        max_keys_per_request: number of objects to list down
+        """
+        for obj in self.get_matching_s3_objects(bucket=bucket, object_path=object_path, max_keys_per_request=max_keys_per_request):
+            yield obj['Key']
+
+    def get_list_of_tables(self, bucket, object_path):
+        """
+        Method to list down the tables under given snapshot path prefixed as:
+        bucket/object_path/{filename}
+
+        Parameters
+        ----------
+        bucket: name of s3 bucket
+        object_path: Path that leads to all tables 
+        """
+        s3_objects = []
+
+        if object_path:
+            for full_object_path in self.get_matching_s3_keys(bucket=bucket, object_path=object_path, max_keys_per_request=1):
+                s3_objects.append(bucket + '/' + full_object_path)
+
+        return s3_objects

--- a/tagr/storage/aws_helper.py
+++ b/tagr/storage/aws_helper.py
@@ -1,7 +1,7 @@
-'''
+"""
 code heavy helper functions for Aws.py
+"""
 
-'''
 import boto3
 
 class AwsHelper:
@@ -33,6 +33,8 @@ class AwsHelper:
             # The S3 API response is a large blob of metadata.
             # 'Contents' contains information about the listed objects.
             resp = s3.list_objects_v2(**kwargs)
+            print("s3 response")
+            print(resp)
 
             try:
                 contents = resp['Contents']

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -50,8 +50,8 @@ class Local:
             "{}/{}/{}/{}.pkl".format(proj, experiment, tag, filename), "wb"
         ))
     
-    def list(self, proj, experiment, tag):
-        '''
+    def __list(self, proj, experiment, tag):
+        """
         gets list of files/folders located at {proj}/{experiment}/{tag}
 
         Parameters
@@ -59,7 +59,7 @@ class Local:
         proj: project name
         experiment: experiment name
         tag: custom commit message (optional)
-        '''
+        """
         path = proj + "/" + experiment
         if tag:
             path += ('/' + tag)

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -1,6 +1,6 @@
 import json
 import pickle
-
+import os
 
 class Local:
     def dump_csv(self, df, proj, exp, tag, filename):
@@ -46,3 +46,7 @@ class Local:
         pickle.dump(pickle_object, open(
             "{}-{}-{}-{}.pkl".format(proj, exp, tag, filename), "wb"
         ))
+    
+    def fetch(self, proj, path):
+        folders = os.listdir('/' + proj + '/' + path)
+        return folders

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -50,7 +50,7 @@ class Local:
             "{}/{}/{}/{}.pkl".format(proj, experiment, tag, filename), "wb"
         ))
     
-    def __list(self, proj, experiment, tag):
+    def _Tags__list(self, proj, experiment, tag):
         """
         gets list of files/folders located at {proj}/{experiment}/{tag}
 

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -185,4 +185,4 @@ class Tags(object):
         elif dump == 'local':
             self.storage_provider = Local()
             
-        return self.storage_provider.list(proj, experiment, tag)
+        return self.storage_provider.__list(proj, experiment, tag)

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -88,7 +88,7 @@ class Tags(object):
         Parameters
         ----------
         proj: project name on metadata provider
-        exp: experiment name
+        experiment: experiment name
         tag: custom commit message
         dump: destination for experiment data to be dumped ('aws', 'gcp', 'azure', 'local')
             - for dump, asssume local by default if destination not provided
@@ -174,8 +174,9 @@ class Tags(object):
         Parameters
         ----------
         proj: project name on metadata provider
-        dir: directory path to look up
-        dump: destination for experiment data to be fetched from ('aws', 'gcp', 'azure', 'local')
+        experiment: experiment name
+        tag: custom commit message (optional)
+        dump: destination for experiment data to be fetched from ('aws', 'local')
             - for dump, asssume local by default if destination not provided
         """
         # determine which storage provider to use

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -186,5 +186,3 @@ class Tags(object):
             self.storage_provider = Local()
             
         return self.storage_provider.list(proj, experiment, tag)
-        #return self.storage_provider.fetch(proj, path)
-

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -164,7 +164,7 @@ class Tags(object):
         for model in models:
             model_object = summary["artifact"].loc[model]
             pickle_byte_obj = pickle.dumps(model_object)
-            logger.info("pushing " + str(model) + "metadata json to S3")
+            logger.info("flushing " + str(model) + "metadata json to S3")
             self.storage_provider.dump_pickle(pickle_byte_obj, proj, experiment, tag, model)
 
     def list(self, proj, experiment, tag="", dump='local'):

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -164,3 +164,24 @@ class Tags(object):
             pickle_byte_obj = pickle.dumps(model_object)
             logger.info("pushing " + str(model) + "metadata json to S3")
             self.storage_provider.dump_pickle(pickle_byte_obj, proj, exp, tag, model)
+
+    def fetch(self, proj, path, dump='local'):
+        """
+        fetches previously flushed experiments
+
+        Parameters
+        ----------
+        proj: project name on metadata provider
+        dir: directory path to look up
+        dump: destination for experiment data to be fetched from ('aws', 'gcp', 'azure', 'local')
+            - for dump, asssume local by default if destination not provided
+        """
+        # determine which storage provider to use
+        if dump == 'aws':
+            self.storage_provider = Aws()
+        elif dump == 'local':
+            self.storage_provider = Local()
+            
+        return 'hello'
+        #return self.storage_provider.fetch(proj, path)
+


### PR DESCRIPTION
# Description
This is part 1 of 2 for https://github.com/tagr-dev/tagr/issues/10
Added .list() method for tagr so now users can get a list of objects by looking up a specific directory in local storage or aws s3. After a user flushes metadata for a particular experiment, the user can then lookup what metadata they have pushed in previous experiments, allowing for granularity up to the tag level in a folder directory path. ```{project}/{experiment}/{tag}```

Here's an example:
Lets say I flushed some metadata to s3:
```
tag.flush('waterflow-tagr', 'eric', 'aws', 'second_experiment_tag')
# project : waterflow-tagr
# experiment : eric
# dump : aws
# tag : second_experiment_tag
```
Now, I want to see what metadata I have pushed for ```waterflow-tagr/eric/second_experiment_tag```
```
tag.list('waterflow-tagr', 'eric', 'second_experiment_tag', 'aws')
```
which returns:
```
['eric/second_experiment_tag/X_train.csv',
 'eric/second_experiment_tag/df_summary.json',
 'eric/second_experiment_tag/linmodel.pkl',
 'eric/second_experiment_tag/model.pkl',
 'eric/second_experiment_tag/y_pred.csv',
 'eric/second_experiment_tag/y_train.csv']
```

# What's changed
- Added .list() methods for both ```aws.py``` and ```local.py``` classes
- In the case of aws, we needed to figure out a way to lookup s3 object paths programmatically. I used the helper functions provided in here https://mageswaran1989.medium.com/list-s3-folders-with-boto3-b2d7fbd631e9 as a template to help us lookup s3 object paths. Made some simplifications for our use case, but its still a lot of code. Maybe we can figure out an even simpler way that requires less code in the future?
- Edited a few docstrings


# Some remarks
Yeah I know, we should probably refactor .flush() so that the ordering of the input parameters should be the same for both flush() and list(). Right now it looks like this:
```
def flush(self, proj, experiment, dump='local', tag=None):
def list(self, proj, experiment, tag="", dump='local'):
```
 We can do that in a future PR




