### PR TITLE
Rename Tags class to Tagr

### DIFF
--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -66,7 +66,7 @@ class Aws:
             Body=pickle_object
         )
         
-    def _Tags__list(self, proj, experiment, tag):
+    def _Tagr__list(self, proj, experiment, tag):
         """
         gets list of files/folders located at {proj}/{experiment}/{tag}
         Parameters
@@ -82,7 +82,7 @@ class Aws:
 
         return aws_helper.get_list_of_tables(proj, object_path)
     
-    def _Tags__fetch(self, proj, experiment, tag, filename):
+    def _Tagr__fetch(self, proj, experiment, tag, filename):
         """
         fetches object located at {proj}/{experiment}/{tag}/{filename}
         Parameters

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -49,7 +49,7 @@ class Local:
         """
         pickle.dump(model, open("{}/{}/{}/{}.pkl".format(proj, experiment, tag, filename), 'wb'))
     
-    def _Tags__list(self, proj, experiment, tag):
+    def _Tagr__list(self, proj, experiment, tag):
         """
         gets list of files/folders located at {proj}/{experiment}/{tag}
 
@@ -66,7 +66,7 @@ class Local:
         folders = os.listdir(path)
         return folders
 
-    def _Tags__fetch(self, proj, experiment, tag, filename):
+    def _Tagr__fetch(self, proj, experiment, tag, filename):
         path = proj + "/" + experiment + "/" + tag + "/" + filename
         if path.endswith(".csv"):
             obj = pd.read_csv(path)

--- a/tagr/tagging/__init__.py
+++ b/tagr/tagging/__init__.py
@@ -1,1 +1,1 @@
-from tagr.tagging.artifacts import Tags
+from tagr.tagging.artifacts import Tagr

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -10,7 +10,7 @@ from tagr.storage.local import Local
 logger = logging.getLogger("tagging_artifact")
 
 
-class Tags(object):
+class Tagr(object):
     def __init__(self):
         self.queue = {}
         self.cust_queue = {}


### PR DESCRIPTION
# Description
The title says it all. 
Just changed the Tags class to Tagr.
Importing library and instantiation
```
from tagr.tagging.artifacts import Tagr

tag = Tagr()
```
