### PR TITLE
New Data Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root &
 # Instructions
 1. Import tagr 
 ```
-from tagr.tagging.artifacts import Tags
+from tagr.tagging.artifacts import Tagr
 from tagr.config import EXP_OBJECTS, OBJECTS
 ```
 2. After building your model and performing exploratory data analysis of your dataset, tag your training/testing/prediction datasets and model
 ```
+tag = Tagr()
 x = tag.save(mock_df1, "X_train", "int")
 y = tag.save(mock_df2, "y_train")
 model = tag.save(RandomForestClassifier(max_depth=30), "model")
@@ -38,9 +39,9 @@ tag.inspect()
 4. Push all your tagged artifacts to a cloud storage solution of your choice
 ```
 # s3
-tag.flush('waterflow-tagr', 'dev/eric', 'aws', 'demo')
+tag.flush('tagr-dev', 'dev/eric', 'aws', 'demo')
 
 # local
-tag.flush('waterflow-tagr', 'eric', 'demo')
+tag.flush('tagr-dev', 'eric', 'demo')
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy >=1.15
 pandas
 boto3
+black
 s3fs
 pylint
 jupyter

--- a/tagr/config.py
+++ b/tagr/config.py
@@ -1,6 +1,7 @@
-OBJECTS = ['X_train', 'X_test', 'y_train', 'y_test', 'model', 'trained_model',
-           'prediction', 'y_pred', 'accuracy']
-
 EXP_OBJECTS = ['X_train', 'X_test', 'y_train', 'y_test', 'model', 'prediction', 'y_pred']
 
 EXP_OBJECT_TYPES = ['dataframe', 'dataframe', 'dataframe', 'dataframe', 'model', 'dataframe', 'dataframe']
+
+OBJECTS = {'X_train': 'dataframe', 'X_test': 'dataframe', 'y_train': 'dataframe', 'y_test': 'dataframe', 'model': 'model',
+           'trained_model': 'model', 'prediction': 'dataframe', 'y_pred': 'dataframe', 'accuracy': 'dataframe',
+           'int': 'primitive', 'float': 'primitive', 'str': 'primitive', 'bool': 'primitive'}

--- a/tagr/storage/aws.py
+++ b/tagr/storage/aws.py
@@ -15,6 +15,7 @@ csv_buffer = StringIO()
 class Aws:
     def __init__(self):
         self.S3 = boto3.resource("s3")
+        self.name = 'AWS'
 
     def dump_csv(self, df, proj, experiment, tag, filename):
         """

--- a/tagr/storage/local.py
+++ b/tagr/storage/local.py
@@ -7,6 +7,8 @@ import pandas as pd
 logger = logging.getLogger("saving experiment to local storage")
 
 class Local:
+    name = 'Local'
+
     def dump_csv(self, df, proj, experiment, tag, filename):
         """
         turns dataframe into csv and saves it to local storage

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -10,9 +10,9 @@ from tagr.storage.local import Local
 logger = logging.getLogger("tagging_artifact")
 
 
-class Artifact():
-    def __init__(self, val, obj_name, dtype = None) :
-        self.val = val 
+class Artifact:
+    def __init__(self, val, obj_name, dtype=None):
+        self.val = val
         self.obj_name = obj_name
 
         if dtype:
@@ -21,13 +21,19 @@ class Artifact():
             self.dtype = OBJECTS[obj_name]
 
     def __repr__(self):
-        return "val: {0}, obj_name: {1}, dtype: {2}".format(self.val, self.obj_name, self.dtype)
+        return "val: {0}, obj_name: {1}, dtype: {2}".format(
+            self.val, self.obj_name, self.dtype
+        )
+
 
 class Tagr(object):
     def __init__(self):
         self.queue = {}
         self.cust_queue = {}
         self.storage_provider = Local()
+
+        self.col_types_dict = {}
+        self.col_stats_dict = {}
 
     def save(self, artifact, obj_name: str, dtype: str = None):
         """
@@ -58,7 +64,7 @@ class Tagr(object):
         `artifact` to preserve declarative interface
         """
         if obj_name in OBJECTS:
-            self.queue[obj_name ] = Artifact(artifact, obj_name)
+            self.queue[obj_name] = Artifact(artifact, obj_name)
         elif not dtype:
             raise ValueError("dtype must be provided if custom obj")
         else:
@@ -68,7 +74,7 @@ class Tagr(object):
 
     def ret_queue(self) -> dict:
         return self.queue
-    
+
     def inspect(self):
         """
         Returns pd.Dataframe of tagged variables and their values
@@ -77,11 +83,9 @@ class Tagr(object):
         for k, artifact in self.queue.items():
             data.append([artifact.obj_name, artifact.val, artifact.dtype])
 
-        return pd.DataFrame(
-            data, columns = ['obj_name', 'val', 'dtype']
-            )
+        return pd.DataFrame(data, columns=["obj_name", "val", "dtype"])
 
-    def flush(self, proj, experiment, tag=None, dump='local'):
+    def flush(self, proj, experiment, tag=None, dump="local"):
         """
         Pushes all variables from `queue` to metadata store.
         Generates metadata for artifacts of type pd.Dataframe in JSON
@@ -95,47 +99,26 @@ class Tagr(object):
         dump: destination for experiment data to be dumped ('aws', 'gcp', 'azure', 'local')
             - for dump, asssume local by default if destination not provided
         """
-        
+
         # use datetime as index if tag name not provided
         if not tag:
             logger.info("using datetime as tag")
             tag = str(datetime.utcnow())
 
-        # determine which storage provider to use
-        if dump == 'aws':
+        if dump == "aws":
             self.storage_provider = Aws()
-        elif dump == 'local':
+        elif dump == "local":
             self.storage_provider = Local()
             # if folder directory doesnt exist, then create new directory
             self.storage_provider.build_path(proj, experiment, tag)
 
+        experiment_params = {"proj": proj, "experiment": experiment, "tag": tag}
+
         #####################
         # generate metadata #
         #####################
-        logger.info("generating metadata json file")
         summary = self.inspect()
-        # # filter for not null df elements
-        # df_names = list(
-        #     summary[
-        #         (pd.notnull(summary["artifact"])) & (summary["type"] == "dataframe")
-        #         ].index
-        # )
-
-        col_types_dict = {}
-        col_stats_dict = {}
-
-        logger.info("collecting dataframe types and summary stats for json file")
-        for df_name in df_names:
-            df = summary["artifact"].loc[df_name]
-            col_types_dict[df_name] = dict(zip(df.columns, df.dtypes.map(lambda x: x.name)))
-            col_stats_dict[df_name] = df.describe().to_dict()
-
-            #############
-            # Push dfs #
-            #############
-            # todo: save larger dfs as parquet, maybe partition as well
-            logger.info("flushing dataframes as csv to " + str(dump))
-            self.storage_provider.dump_csv(df, proj, experiment, tag, df_name)
+        self._flush_dfs(summar, experiment_params)
 
         nums_and_strings = list(
             summary[summary["type"].isin(["int", "float", "str"])].index
@@ -164,9 +147,42 @@ class Tagr(object):
         for model in models:
             model_object = summary["artifact"].loc[model]
             logger.info("flushing " + str(model) + "metadata json to S3")
-            self.storage_provider.dump_pickle(model_object, proj, experiment, tag, model)
+            self.storage_provider.dump_pickle(
+                model_object, proj, experiment, tag, model
+            )
 
-    def list(self, proj, experiment, tag=None, dump='local'):
+    def _flush_dfs(self, summary, experiment_params):
+        """
+        Collects summary statistics for all tagged dataframes in provided summary df.
+        Saves statistics to `col_types_dict` and `col_types_dict` class attributes.
+        Pushes dataframes to metadata provider as csv
+
+        Parameters
+        ----------
+        summary: tagg varaibles summary DataFrame returned from Tagr.inspect()
+        experiment_params: dict of experiment namespace variables
+        """
+        summary_dfs = summary[summary["dtype"] == "dataframe"]
+
+        logger.info("collecting dataframe types and summary stats for json file")
+        for i, row in summary_dfs.iterrows():
+            df = row["val"]
+            df_name = row["obj_name"]
+            self.col_types_dict[df_name] = dict(
+                zip(df.columns, df.dtypes.map(lambda x: x.name))
+            )
+            self.col_stats_dict[df_name] = df.describe().to_dict()
+
+            logger.info("flushing dataframes as csv to " + str(dump))
+            self.storage_provider.dump_csv(
+                df,
+                experiment_params["proj"],
+                experiment_params["experiment"],
+                experiment_params["tag"],
+                df_name
+            )
+
+    def list(self, proj, experiment, tag=None, dump="local"):
         """
         fetches previously flushed experiments
         Parameters
@@ -178,18 +194,17 @@ class Tagr(object):
             - for dump, asssume local by default if destination not provided
         """
         # determine which storage provider to use
-        if dump == 'aws':
+        if dump == "aws":
             self.storage_provider = Aws()
-        elif dump == 'local':
+        elif dump == "local":
             self.storage_provider = Local()
 
         return self.storage_provider.__list(proj, experiment, tag)
 
-    def fetch(self, proj, experiment, tag, filename, dump='local'):
-        if dump == 'aws':
+    def fetch(self, proj, experiment, tag, filename, dump="local"):
+        if dump == "aws":
             self.storage_provider = Aws()
-        elif dump == 'local':
+        elif dump == "local":
             self.storage_provider = Local()
 
         return self.storage_provider.__fetch(proj, experiment, tag, filename)
-

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -26,7 +26,7 @@ class Tagr(object):
         obj: str. type of variable to be store.
             Choice of config.OBJECTS
             If you pass a string not in config.OBJECTS
-            WaterFlow will store the object under the cust dir
+            Tagr will store the object under the cust dir
         dtype: type or None, Default None
             used for storing custom variables not in OBJECTS
             Behavior as follows:

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -118,10 +118,10 @@ class Tagr(object):
         # generate metadata #
         #####################
         summary = self.inspect()
-        self._flush_dfs(summar, experiment_params)
+        self._flush_dfs(summary, experiment_params)
 
         nums_and_strings = list(
-            summary[summary["type"].isin(["int", "float", "str"])].index
+            summary[summary["dtype"].isin(["int", "float", "str"])].index
         )
 
         nums_and_strings_dict = {}
@@ -132,8 +132,8 @@ class Tagr(object):
             nums_and_strings_dict[i] = num_or_str
 
         df_metadata = {
-            "types": col_types_dict,
-            "stats": col_stats_dict,
+            "types": self.col_types_dict,
+            "stats": self.col_stats_dict,
             "nums_and_strings": nums_and_strings_dict,
         }
 
@@ -173,7 +173,7 @@ class Tagr(object):
             )
             self.col_stats_dict[df_name] = df.describe().to_dict()
 
-            logger.info("flushing dataframes as csv to " + str(dump))
+            logger.info("flushing dataframes as csv to " + self.storage_provider.name)
             self.storage_provider.dump_csv(
                 df,
                 experiment_params["proj"],

--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -10,9 +10,18 @@ from tagr.storage.local import Local
 logger = logging.getLogger("tagging_artifact")
 
 
+class Artifact():
+    def __init__(self, val, obj, dtype = None) :
+        self.val = val 
+        self.obj = obj
+        self.dtype = dtype
+
+    def __repr__(self):
+        return "val: {0}, obj: {1}, dtype: {2}".format(self.val, self.obj, self.dtype)
+
 class Tagr(object):
     def __init__(self):
-        self.queue = {}
+        self.queue = []
         self.cust_queue = {}
         self.storage_provider = Local()
 
@@ -46,7 +55,7 @@ class Tagr(object):
         """
 
         if obj in OBJECTS:
-            self.queue[obj] = artifact
+            self.queue.append(Artifact(artifact, obj))
         elif not dtype:
             raise ValueError("dtype must be provided if custom obj")
         else:


### PR DESCRIPTION
**Whats Changed?**
Implementing a new data class to contain all artifact level information. Perviously, when a variable was tagged, it would be stored in a dictionary with as an anonymous tuple of `(artifact, dtype)`. This meant accessing the variable or its type would require vague index based calls like `queue[1]`. The new data class `Artifact` stores all model level information as class attributes. It works with the current `OBJECTS` dictionary to automatically assign a `dtype` to recognized objects. The class puts us in a good position in the future to do more with artifacts like type inference, stronger typing, and metric pre-computation.  

**Other Notable Changes**
Partitioned steps in `flush()` to singular private methods => `_get_primitive_objs_dict`, `_flush_metadata_json`, `_flush_dfs`, `_flush_non_dfs`

**Big detailed list of change until we implement change log**

1. Remove unnecessary comments (still needs more clean up)
2. Updated documentation
3. change name from WaterFlow to Tagr in docs
4. made quote usage consistent
5. convert `OBJECTS` to dictionary with mapped dtype as key
6. add `black` as dep for lint, should prob create a dev requirements file some time for docker


