### PR TITLE
AwsHelper Tests

### DIFF
--- a/tagr/storage/aws_helper.py
+++ b/tagr/storage/aws_helper.py
@@ -102,7 +102,7 @@ class AwsHelper:
         )
 
         if object_path.endswith('.csv'):
-            obj = pd.read_csv(response['Body'])
+            obj = pd.read_csv(response['Body'], index_col=0)
         else:
             serialized_model = response['Body'].read()
             obj = pickle.loads(serialized_model)

--- a/test/unit/storage/test_aws.py
+++ b/test/unit/storage/test_aws.py
@@ -129,3 +129,51 @@ class AwsHelperTest(unittest.TestCase):
         )
         keys_list = [key for key in matching_keys_res]
         self.assertEqual(expected_key, keys_list)
+
+    def test_get_list_of_tables(self):
+        expected_res = [
+            "{}/{}/unit_test_tag/text1.txt".format(PROJ, EXPERIMENT),
+            "{}/{}/unit_test_tag/text2.txt".format(PROJ, EXPERIMENT),
+        ]
+
+        aws_helper = AwsHelper()
+        conn = self.create_connection()
+
+        conn.Object(PROJ, "{}/{}/text1.txt".format(EXPERIMENT, TAG)).put(
+            Body="content_of_text1"
+        )
+        conn.Object(PROJ, "{}/{}/text2.txt".format(EXPERIMENT, TAG)).put(
+            Body="content_of_text2"
+        )
+
+        list_of_tables = aws_helper.get_list_of_tables(
+            bucket=PROJ, object_path="{}/{}".format(EXPERIMENT, TAG)
+        )
+        self.assertEqual(expected_res, list_of_tables)
+
+    def test_get_object(self):
+        expected_df = DF
+        expected_dict = {"test_key": "test_val"}
+
+        storage_provider = Aws()
+        aws_helper = AwsHelper()
+
+        storage_provider.dump_csv(
+            df=DF, proj=PROJ, experiment=EXPERIMENT, tag=TAG, filename="test_data"
+        )
+        df_content = aws_helper.get_object(
+            bucket=PROJ, object_path="{}/{}/test_data.csv".format(EXPERIMENT, TAG)
+        )
+        pd._testing.assert_frame_equal(expected_df, df_content)
+
+        storage_provider.dump_pickle(
+            model=expected_dict,
+            proj=PROJ,
+            experiment=EXPERIMENT,
+            tag=TAG,
+            filename="test_dict",
+        )
+        pickle_content = aws_helper.get_object(
+            bucket=PROJ, object_path="{}/{}/test_dict.pkl".format(EXPERIMENT, TAG)
+        )
+        self.assertEqual(expected_dict, pickle_content)

--- a/test/unit/storage/test_aws.py
+++ b/test/unit/storage/test_aws.py
@@ -117,7 +117,6 @@ class AwsHelperTest(unittest.TestCase):
             Body="content_of_text2"
         )
 
-        # todo: deserialize and get to match value
         matching_objs_res = aws_helper.get_matching_s3_objects(
             bucket=PROJ, object_path="{}/{}".format(EXPERIMENT, TAG)
         )


### PR DESCRIPTION
**Whats Changed?**
Code coverage for AwsHelper class was non-existent. Changing that. Modified `AwsHelper.get_object()` behaviour for csvs to automatically ignore the index column