### PR TITLE
add rm()

### DIFF
--- a/tagr/tagging/artifacts.py
+++ b/tagr/tagging/artifacts.py
@@ -98,6 +98,20 @@ class Tagr(object):
 
         return artifact
 
+    def rm(self, obj_name):
+        """
+        Remove the supplied object from the dictionary of saved objects
+
+        Parameter
+        ---------
+        obj_name: str. Name of object to be removed
+
+        """
+        if obj_name in self.queue:
+            del self.queue[obj_name]
+        else:
+            raise KeyError("{} is not a key in the queue".format(obj_name))
+
     def ret_queue(self) -> dict:
         return self.queue
 

--- a/test/unit/test_tagging.py
+++ b/test/unit/test_tagging.py
@@ -75,6 +75,26 @@ class TaggingTest(unittest.TestCase):
 
         self.assertEqual(queue_length, 1)
 
+    def test_rm(self):
+        expected_length = 1
+        expected_val = 2
+        self.tag = Tagr()
+
+        self.tag.save(1, "int1", "primitive")
+        self.tag.save(2, "int2", "primitive")
+        self.tag.rm("int1")
+        queue = self.tag.ret_queue()
+        queue_length = len(queue)
+        stored_int = queue["int2"].val
+
+        self.assertEqual(queue_length, expected_length)
+        self.assertEqual(expected_val, stored_int)
+
+    def test_rm_error_handling(self):
+        self.tag = Tagr()
+
+        self.assertRaises(KeyError, lambda: self.tag.rm("non_existent_obj"))
+
     def test_summary(self):
         data = [
             {"obj_name": "num1", "val": 2.0, "dtype": "primitive"},


### PR DESCRIPTION
**Whats Changed**
Previously when an object was tagged, there was no way to remove it. Can you believe that??? Yea I dropped the ball.

Now Tagr.rm() will remove the tagged object from the queue 